### PR TITLE
Add GitHub Actions CI for Selenium tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Set up Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Run tests
+        run: mvn -B clean test
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: target/surefire-reports/
+          if-no-files-found: ignore

--- a/src/main/java/utils/WebDriverManager.java
+++ b/src/main/java/utils/WebDriverManager.java
@@ -25,8 +25,19 @@ public class WebDriverManager {
             options.setExperimentalOption("prefs", prefs);
             options.addArguments("--incognito");
 
+            // Run headless on CI (GitHub Actions sets CI=true); stay visible locally.
+            boolean headless = Boolean.parseBoolean(System.getenv("CI"));
+            if (headless) {
+                options.addArguments("--headless=new");
+                options.addArguments("--no-sandbox");
+                options.addArguments("--disable-dev-shm-usage");
+                options.addArguments("--window-size=1920,1080");
+            }
+
             driver = new ChromeDriver(options);
-            driver.manage().window().maximize();
+            if (!headless) {
+                driver.manage().window().maximize();
+            }
         }
         return driver;
     }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/tests.yml` — runs `mvn clean test` on every push and pull request (all branches)
- Uses `ubuntu-latest` with Temurin JDK 17, Maven dependency caching, and a stable Chrome
- `WebDriverManager` now launches Chrome **headless** when `CI=true` (set automatically by GitHub Actions), while staying visible for local runs
- Uploads Surefire reports as a build artifact for inspection on failures

## Testing
- `CI=true mvn -B clean test` locally → all 10 tests pass headless (no browser window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)